### PR TITLE
Fix Arbitrary instance for ByronAddress

### DIFF
--- a/src/Cardano/Types/ByronAddress.purs
+++ b/src/Cardano/Types/ByronAddress.purs
@@ -45,7 +45,7 @@ derive newtype instance DecodeAeson ByronAddress
 
 instance Arbitrary ByronAddress where
   arbitrary = pure $ unsafePartial $ fromJust $ fromBase58
-    "37btjrVyb4KDXBNC4haBVPCrro8AQPHwvCMp3RFhhSVWwfFmZ6wwzSK6JK1hY6wHNmtrpTf1kdbva8TCneM2YsiXT7mrzT21EacHnPpz5YyUdj64na"
+    "KjgoiXJS2coTnqpCLHXFtd89Hv9ttjsE6yW4msyLXFNkykUpTsyBs85r2rDDia2uKrhdpGKCJnmFXwvPSWLe75564ixZWdTxRh7TnuaDLnHx"
 
 fromBase58 :: Base58String -> Maybe ByronAddress
 fromBase58 = map wrap <<< toMaybe <<< byronAddress_fromBase58


### PR DESCRIPTION
The previous hardcoded address contained unsupported network info.