### PR TITLE
Preserve key order when converting PlutusMap to CSL multimap

### DIFF
--- a/src/Cardano/Types/PlutusData.purs
+++ b/src/Cardano/Types/PlutusData.purs
@@ -57,11 +57,11 @@ import Data.List (fromFoldable, uncons) as List
 import Data.Log.Tag (TagSet, tag, tagSetTag)
 import Data.Log.Tag as TagSet
 import Data.Map (Map)
-import Data.Map (empty, fromFoldableWith, insert, lookup, toUnfoldable) as Map
+import Data.Map (empty, insert, lookup) as Map
 import Data.Maybe (Maybe(Just, Nothing), fromJust)
 import Data.Newtype (unwrap, wrap)
 import Data.Nullable (toMaybe)
-import Data.Profunctor.Strong (second, (***))
+import Data.Profunctor.Strong ((***))
 import Data.Show.Generic (genericShow)
 import Data.Traversable (for)
 import Data.Tuple (Tuple(Tuple))

--- a/test/Fixtures.purs
+++ b/test/Fixtures.purs
@@ -39,6 +39,7 @@ module Test.Fixtures
   , plutusDataFixture8
   , plutusDataFixture9
   , plutusDataFixture10
+  , plutusDataFixture11
   , plutusDataFixture8Bytes
   , plutusDataFixture8Bytes'
   , plutusScriptFixture1
@@ -1600,6 +1601,13 @@ plutusDataFixture10 = Map
   [ plutusDataFixture5 /\ plutusDataFixture5
   , plutusDataFixture5 /\ plutusDataFixture2
   , plutusDataFixture5 /\ plutusDataFixture3
+  ]
+
+plutusDataFixture11 :: PlutusData
+plutusDataFixture11 = Map
+  [ Integer (BigInt.fromInt 3) /\ Integer (BigInt.fromInt 10)
+  , Integer (BigInt.fromInt 1) /\ Integer (BigInt.fromInt 12)
+  , Integer (BigInt.fromInt 2) /\ Integer (BigInt.fromInt 10)
   ]
 
 redeemerFixture1 :: Redeemer

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -25,6 +25,7 @@ import Test.Fixtures
   , nativeScriptFixture7
   , plutusDataFixture1
   , plutusDataFixture10
+  , plutusDataFixture11
   , plutusDataFixture2
   , plutusDataFixture3
   , plutusDataFixture4
@@ -85,6 +86,7 @@ suite = do
       roundtripTest "plutusDataFixture8" plutusDataFixture8
       roundtripTest "plutusDataFixture9" plutusDataFixture9
       roundtripTest "plutusDataFixture10" plutusDataFixture10
+      roundtripTest "plutusDataFixture11" plutusDataFixture11
     group "Transaction" do
       roundtripTest "txFixture1" txFixture1
       roundtripTest "txFixture2" txFixture2


### PR DESCRIPTION
Fixes https://github.com/mlabs-haskell/purescript-cardano-types/issues/14